### PR TITLE
added < 1 min to read message on posts & index

### DIFF
--- a/_includes/ert.html
+++ b/_includes/ert.html
@@ -3,4 +3,6 @@
 {% endcapture %}
 {% unless words contains "-" %}
   <span><i class="fa fa-clock-o"></i> {{ words | plus: 250 | divided_by: 180 | append: " min to read" }}</span>
+{% else %}
+  <span><i class="fa fa-clock-o"></i> < 1 min to read</span>
 {% endunless %}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@ title: Home
     {% endcapture %}
     {% unless words contains "-" %}
       {{ words | plus: 250 | divided_by: 180 | append: " min to read" }}
+    {% else %}
+      < 1 min to read
     {% endunless %} |
     {% include edit.html %}
     </span>


### PR DESCRIPTION
Short posts were displaying the "Time to read" calculation incorrectly. 

Fixes https://github.com/sroberts/sroberts.github.io/issues/47.