### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Dependencies
 markdown:         kramdown
-highlighter:      true
+highlighter:      pygments
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data", "strikethrough"]
 exclude: [vendor]


### PR DESCRIPTION
> Your site is using the 'true' highlighter, which is not currently supported on GitHub Pages. Highlighting on your site has been disabled. To re-enable, change your 'highlighter' value to 'pygments' in your '_config.yml'. Check out https://help.github.com/articles/page-build-failed-config-file-error#highlighting-errors for more information. 

Got a warning from CI, seems like I should fix this.